### PR TITLE
Adds `token` to GET request

### DIFF
--- a/chrome/source/scrumboard.js
+++ b/chrome/source/scrumboard.js
@@ -206,6 +206,7 @@
 		var url = 'https://api.github.com/repos/' + _ORGA + '/' + _REPO + '/issues?per_page=254&state=' + state;
 
 		xhr.open('GET', url, true);
+		xhr.setRequestHeader('Authorization', 'token ' + _get('token'));
 
 		xhr.onload = function() {
 


### PR DESCRIPTION
GitHub API returns `404` unless the `token` is sent up as part of the `GET` requests. Eventually, after enough page refreshes, this leads a `403` rate limiting response.

This pull request adds the same method of sending up the `token` in the HTTP header as used in other parts of the code.

<img width="1440" alt="screen shot 2016-03-06 at 7 31 59 pm" src="https://cloud.githubusercontent.com/assets/10425343/13558418/6b8d46b4-e3d2-11e5-84aa-2a0c11da3fc9.png">
